### PR TITLE
feat: 메모리 추적 배열 목업 데이터를 이용한 동적 차트 구현 + 차트 재생 기능

### DIFF
--- a/src/component/Chart.js
+++ b/src/component/Chart.js
@@ -1,12 +1,53 @@
 import React, { useEffect, useState } from "react";
 import LineChart from "../utils/msChart";
+import styled from "styled-components";
+
+const Button = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: row;
+  color: white;
+  font-size: 18px;
+  height: 30px;
+  width: 100px;
+  background-color: #1e90ff;
+  margin: 10px;
+  border: none;
+  border-radius: 20px;
+`;
+
+const Controller = styled.div`
+  display: flex;
+`;
 
 export default function Chart() {
   const [chart, setChart] = useState();
 
   useEffect(() => {
-    setChart(new LineChart("lineChart", 5));
+    setChart(new LineChart("lineChart", 5000));
   }, []);
 
-  return <canvas id="lineChart" width="400px" height="300px"></canvas>;
+  function handleChartPlay() {
+    chart.playback();
+  }
+
+  function handleChartPause() {
+    chart.pause();
+  }
+
+  function handleChartStop() {
+    chart.stop();
+  }
+
+  return (
+    <>
+      <canvas id="lineChart" width="400px" height="300px"></canvas>
+      <Controller>
+        <Button onClick={handleChartPlay}>시작</Button>
+        <Button onClick={handleChartPause}>일시정지</Button>
+        <Button onClick={handleChartStop}>종료</Button>
+      </Controller>
+    </>
+  );
 }

--- a/src/component/Chart.js
+++ b/src/component/Chart.js
@@ -1,19 +1,11 @@
 import React, { useEffect, useState } from "react";
-import useInterval from "../hooks/useInterval";
 import LineChart from "../utils/msChart";
-//import styled from "styled-components";
 
 export default function Chart() {
   const [chart, setChart] = useState();
 
-  useInterval(() => {
-    //일단 max가 100이라 랜덤 100으로 설정
-    //데이터가 들어오는 곳
-    chart.updateData([Date.now(), Math.random() * 100]);
-  }, 1000);
-
   useEffect(() => {
-    setChart(new LineChart("lineChart"));
+    setChart(new LineChart("lineChart", 5));
   }, []);
 
   return <canvas id="lineChart" width="400px" height="300px"></canvas>;

--- a/src/utils/msChart.js
+++ b/src/utils/msChart.js
@@ -49,18 +49,39 @@ export default class LineChart {
     this.chartWidth = this.canvasWidth - Y_PADDING;
     this.chartHeight = this.canvasHeight - X_PADDING - TOP_PADDING;
 
-    this.durationTime = durationTime * 1000;
+    this.durationTime = durationTime; // 재생 시간
+    this.intervalID = 0; // 다시 그리기 interval ID
+    this.currentPosition = 0; // 차트 그리기 기준 배열 인덱스
+
+    this.maxMemoryValue = 0; // value 최대값
+    this.minMemoryValue = Infinity; // value 최소값
+    this.maxTimeValue = 0; // Time 최대값
+    this.minTimeValue = Infinity; // Time 최소값
+    this.heightPixelWeights = 0; // 높이 1 pixel 에 value 표현 가중치
+    this.widthPixelWeights = 0; // 너비 1 pixel에 time 표현 가중치
+
+    this.parseMemoryArray(); // heightPixelWeights 얻기
+    return this;
+  }
+
+  playback = () => {
+    if (this.intervalID < 1) {
+      this.intervalID = setInterval(() => {
+        this.updateData();
+      }, this.durationTime / (this.data.at(-1).timestamp - this.data.at(0).timestamp));
+    }
+  };
+
+  pause = () => {
+    clearInterval(this.intervalID);
+    this.intervalID = 0;
+  };
+
+  stop = () => {
+    clearInterval(this.intervalID);
     this.intervalID = 0;
     this.currentPosition = 0;
-
-    this.maxMemoryValue = 0;
-    this.minMemoryValue = Infinity;
-    this.heightPixelWeights = 0;
-    this.widthPixelWeights = 0;
-
-    this.parseMemoryArray();
-    this.setTime();
-  }
+  };
 
   //시간을 실시간으로 세팅하는 함수
   setTime = () => {
@@ -135,6 +156,7 @@ export default class LineChart {
           this.heightPixelWeights * item.memory;
 
         ctx.lineTo(xPosition, yPosition);
+        ctx.ellipse(xPosition, yPosition, 5, 5, 0, 0, 3 * Math.PI);
 
         ctx.fillText(
           new Date(item.timestamp).getMilliseconds(),

--- a/src/utils/msChart.js
+++ b/src/utils/msChart.js
@@ -2,13 +2,45 @@
 const X_PADDING = 25;
 const Y_PADDING = 50;
 const TOP_PADDING = 15;
-const DURATION = 1000 * 30;
-const MAX_VALUE = 100;
+const VIEW_NODE_COUNT = 10;
 const Y_TICK_COUNT = 5;
-const EX_TEXT = "00:00";
 
 export default class LineChart {
-  constructor(id) {
+  constructor(id, durationTime) {
+    this.data = [
+      { timestamp: 1678950904231, memory: 26.470917318911535 },
+      { timestamp: 1678950904232, memory: 94.43471793706901 },
+      { timestamp: 1678950904233, memory: 26.309072289398273 },
+      { timestamp: 1678950904234, memory: 49.17418730834109 },
+      { timestamp: 1678950904235, memory: 31.160896341071865 },
+      { timestamp: 1678950904236, memory: 10.269190763446655 },
+      { timestamp: 1678950904237, memory: 73.7156142120452 },
+      { timestamp: 1678950904238, memory: 26.955150253575553 },
+      { timestamp: 1678950904239, memory: 12.170802365140121 },
+      { timestamp: 1678950904240, memory: 98.04970776474728 },
+      { timestamp: 1678950904241, memory: 5.113529099409275 },
+      { timestamp: 1678950904242, memory: 58.346443031677595 },
+      { timestamp: 1678950904243, memory: 32.87095783395879 },
+      { timestamp: 1678950904244, memory: 99.23909006003522 },
+      { timestamp: 1678950904245, memory: 54.654480598596344 },
+      { timestamp: 1678950904246, memory: 49.17418730834109 },
+      { timestamp: 1678950904247, memory: 31.160896341071865 },
+      { timestamp: 1678950904248, memory: 10.269190763446655 },
+      { timestamp: 1678950904249, memory: 73.7156142120452 },
+      { timestamp: 1678950904250, memory: 26.955150253575553 },
+      { timestamp: 1678950904251, memory: 94.43471793706901 },
+      { timestamp: 1678950904252, memory: 26.309072289398273 },
+      { timestamp: 1678950904253, memory: 49.17418730834109 },
+      { timestamp: 1678950904254, memory: 31.160896341071865 },
+      { timestamp: 1678950904255, memory: 10.269190763446655 },
+      { timestamp: 1678950904256, memory: 73.7156142120452 },
+      { timestamp: 1678950904257, memory: 58.346443031677595 },
+      { timestamp: 1678950904258, memory: 32.87095783395879 },
+      { timestamp: 1678950904259, memory: 99.23909006003522 },
+      { timestamp: 1678950904250, memory: 54.654480598596344 },
+      { timestamp: 1678950904261, memory: 49.17418730834109 },
+    ];
+
     this.canvas = document.getElementById(id);
     this.ctx = this.canvas.getContext("2d");
 
@@ -17,33 +49,38 @@ export default class LineChart {
     this.chartWidth = this.canvasWidth - Y_PADDING;
     this.chartHeight = this.canvasHeight - X_PADDING - TOP_PADDING;
 
-    this.data = [];
+    this.durationTime = durationTime * 1000;
+    this.intervalID = 0;
+    this.currentPosition = 0;
 
-    this.xFormatWidth = this.ctx.measureText(EX_TEXT).width;
+    this.maxMemoryValue = 0;
+    this.minMemoryValue = Infinity;
+    this.heightPixelWeights = 0;
+    this.widthPixelWeights = 0;
+
+    this.parseMemoryArray();
     this.setTime();
-    this.drawChart();
   }
 
   //시간을 실시간으로 세팅하는 함수
   setTime = () => {
-    this.endTime = Date.now();
-    this.startTime = this.endTime - DURATION;
-    this.setXInterval();
+    this.startTime = this.data[0].timestamp;
+    this.intervalID = setInterval(() => {
+      this.updateData();
+    }, this.durationTime / (this.data.at(-1).timestamp - this.data.at(0).timestamp));
   };
 
-  setXInterval = () => {
-    let xPoint = 0;
-    let timeInterval = 1000;
-    const test = true;
-    while (test) {
-      xPoint = (timeInterval / DURATION) * this.chartWidth;
-      if (xPoint > this.xFormatWidth) {
-        break;
-      }
-      timeInterval *= 2;
-    }
+  parseMemoryArray = () => {
+    if (this.data.length) {
+      this.data.forEach((item) => {
+        this.minMemoryValue = Math.min(this.minMemoryValue, item.memory);
+        this.maxMemoryValue = Math.max(this.maxMemoryValue, item.memory);
+      });
 
-    this.xTimeInterval = timeInterval;
+      this.heightPixelWeights =
+        (this.chartHeight - Y_PADDING) /
+        (this.maxMemoryValue - this.minMemoryValue);
+    }
   };
 
   //차트를 그리는 함수
@@ -59,13 +96,14 @@ export default class LineChart {
 
     //draw Y
     ctx.lineTo(Y_PADDING, chartHeight + TOP_PADDING);
-    const yInterval = MAX_VALUE / (Y_TICK_COUNT - 1);
+    const yInterval =
+      (this.maxMemoryValue - this.minMemoryValue) / (Y_TICK_COUNT - 1);
     ctx.textAlign = "right";
     ctx.textBaseline = "middle";
     for (let i = 0; i < Y_TICK_COUNT; i++) {
-      const value = i * yInterval;
+      const value = Math.floor(i * yInterval + this.minMemoryValue);
       const yPoint =
-        TOP_PADDING + chartHeight - (value / MAX_VALUE) * chartHeight;
+        TOP_PADDING + chartHeight - i * (chartHeight / Y_TICK_COUNT);
       ctx.fillText(value, Y_PADDING - 3, yPoint);
     }
 
@@ -80,45 +118,45 @@ export default class LineChart {
     ctx.rect(Y_PADDING, 0, chartWidth, canvasHeight);
     ctx.clip();
 
-    let currentTime = this.startTime - (this.startTime % this.xTimeInterval);
-    ctx.textAlign = "center";
-    ctx.textBaseline = "top";
-    while (currentTime < this.endTime + this.xTimeInterval) {
-      const xpoint = ((currentTime - this.startTime) / DURATION) * chartWidth;
-      const date = new Date(currentTime);
-      const text = date.getMinutes() + ":" + date.getSeconds();
-
-      ctx.fillText(text, xpoint, chartHeight + TOP_PADDING + 4);
-      currentTime += this.xTimeInterval;
-    }
-
     // 데이터를 그리는 로직
     // 1. 새로 패스를 그린다고 선언한다.
     // 2. data(배열)을 돌면서 x의 위치와 y의 위치를 생성
     // 3. data가 없다면? -> 해당 좌표에 시작할 수 있도록 좌표를 옮김
     // 4. data가 있다면? -> x의 위치와 y의 위치를 기반으로 라인을 그림
     ctx.beginPath();
-    this.data.forEach((item, index) => {
-      const [time, value] = item;
 
-      const xPosition = ((time - this.startTime) / DURATION) * this.chartWidth;
-      const yPosition =
-        TOP_PADDING + this.chartHeight - (value / MAX_VALUE) * this.chartHeight;
+    this.data
+      .slice(this.currentPosition, this.currentPosition + VIEW_NODE_COUNT)
+      .forEach((item, index) => {
+        const xPosition = (this.chartWidth / VIEW_NODE_COUNT) * (index + 1);
+        const yPosition =
+          TOP_PADDING +
+          this.chartHeight -
+          this.heightPixelWeights * item.memory;
 
-      if (!index) {
-        ctx.moveTo(xPosition, yPosition);
-      } else {
         ctx.lineTo(xPosition, yPosition);
-      }
-    });
+
+        ctx.fillText(
+          new Date(item.timestamp).getMilliseconds(),
+          xPosition,
+          chartHeight + TOP_PADDING + 4,
+        );
+      });
     ctx.stroke();
     ctx.restore();
   };
 
   //데이터를 갱신하는 함수
-  updateData = (data) => {
-    this.data.push(data);
-    this.setTime();
+  updateData = () => {
+    if (!this.data.length) {
+      return;
+    }
+
     this.drawChart();
+    this.currentPosition += 1;
+
+    if (this.currentPosition - VIEW_NODE_COUNT / 2 > this.data.length) {
+      clearInterval(this.intervalID);
+    }
   };
 }


### PR DESCRIPTION
## ✔️PR타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능추가

- [ ] 버그 수정

- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트

- [ ] 기타 사소한 수정

## ✔️개요
<br>

- 메모리 tracking 정보가 담긴 배열을 받아 차트를 그리고 부분적으로 차트를 그려서 재생 가능한 차트를 구성합니다.
- 차트를 동적으로 재생하면서 재생, 일시정지, 다시시작 버튼을 만들어, 차트를 멈춘 후 노드의 세부정보를 쉽게 볼 수 있게 합니다.
<br><br>

## ✔️변경사항
<br>

- 랜덤 숫자를 받아 차트를 그리는 코드에서  한번에 객체 배열을 받아 부분적으로 배열의 한정된 영역으로 차트를 그리고 재생하는 기능을 만들 었습니다.
- 기존에 class 구조를 유지하여 객체 초기화를 하고 외부에서 차트 객체를 사용하기 위해 this를 리턴 하였습니다.
- 컴포넌트에서 setState로 객체를 담아 차트 모듈에서 제공하는 play pause stop 함수로 차트를 제어할 수 있습니다.

<br>

## ✔️스크린샷

<img width="473" alt="chartScreenshot01" src="https://user-images.githubusercontent.com/52302090/225636853-1b44fc4e-be32-4789-a8f1-b0727bb0640a.png">

<br>

## ✔️리뷰어들한테

<br> 배열 10개씩 얻어 그리고 있습니다. 해당 로직을 밀리세컨드로 변경하는 부분에 높은 난이도가 예상 됩니다.
<br> 이해를 돕기위해 추가로 주석을 달았습니다.
<br> new로 차트 객체를 생성하면서 return this 하여 객체를 setState에 담아 사용할 수 있게 구현해 보았습니다.
<br> 노드위치에 원을 그려 표시해 보았는데, 한줄 그리기 처럼 선이 계속 이어져 있습니다. 개선해야 할 부분 입니다.
<br> 