### PR TITLE
feat: y축 동적 수치 반영, 메모리 추적 함수 삽입 타입 추가

### DIFF
--- a/src/component/Chart.js
+++ b/src/component/Chart.js
@@ -3,7 +3,7 @@ import LineChart from "../utils/msChart";
 import styled from "styled-components";
 import { color, style } from "../styles/styleCode";
 
-const CHART_DURATION_TIME = 5000;
+const CHART_DURATION_TIME = 6000;
 
 const Button = styled.button`
   display: flex;
@@ -24,16 +24,15 @@ const Controller = styled.div`
   display: flex;
 `;
 
-export default function Chart() {
+export default function Chart({ data }) {
   const [chart, setChart] = useState();
 
-  const setMemoryArray = (datas) => {
-    setChart(new LineChart("lineChart", datas.result, CHART_DURATION_TIME));
-  };
-
   useEffect(() => {
-    window.electronAPI.executeHeapTrackerReply(setMemoryArray);
-  }, []);
+    if (!data) {
+      return;
+    }
+    setChart(new LineChart("lineChart", data.result, CHART_DURATION_TIME));
+  }, [data]);
 
   function handleChartPlay() {
     if (chart) {
@@ -55,7 +54,7 @@ export default function Chart() {
 
   return (
     <>
-      <canvas id="lineChart" width="400px" height="300px"></canvas>
+      <canvas id="lineChart" width="500px" height="300px"></canvas>
       <Controller>
         <Button onClick={handleChartPlay}>시작</Button>
         <Button onClick={handleChartPause}>일시정지</Button>

--- a/src/component/ChartResult.js
+++ b/src/component/ChartResult.js
@@ -38,25 +38,7 @@ const StyledWrapper = styled.div`
   }
 `;
 
-export default function ChartResult({ data }) {
-  const [RunTime, setRunTime] = useState();
-  const [maxMemory, setmaxMemory] = useState();
-  const [minMemory, setminMemory] = useState();
-  const [nodeCount, setnodeCount] = useState();
-
-  useEffect(() => {
-    if (!data) {
-      return;
-    }
-
-    if (data.result.length > 0) {
-      setRunTime(Number(data.result.at(-1).timeStamp));
-      setmaxMemory(data.result.maxMemoryText);
-      setminMemory(data.result.minMemoryText);
-      setnodeCount(data.result.length);
-    }
-  }, [data]);
-
+export default function ChartResult({ resultData }) {
   return (
     <StyledWrapper>
       <ul>
@@ -64,20 +46,22 @@ export default function ChartResult({ data }) {
         <li className="info">
           <div className="name">TOTAL RUN TIME</div>
           <div className="data">
-            {RunTime}ns, {Math.round(RunTime / 1000000)}ms
+            {Number(resultData.duration)}ns,{" "}
+            {Math.floor(Number(resultData.duration) / 1000000)}
+            ms
           </div>
         </li>
         <li className="info">
           <div className="name">MAX MEMORY</div>
-          <div className="data">{maxMemory}bytes</div>
+          <div className="data">{resultData.maxMemory}bytes</div>
         </li>
         <li className="info">
           <div className="name">MIN MEMORY</div>
-          <div className="data">{minMemory}bytes</div>
+          <div className="data">{resultData.minMemory}bytes</div>
         </li>
         <li className="info">
           <div className="name">TOTAL NODE COUNT</div>
-          <div className="data">{nodeCount}</div>
+          <div className="data">{resultData.count}</div>
         </li>
       </ul>
     </StyledWrapper>

--- a/src/component/ChartResult.js
+++ b/src/component/ChartResult.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import { color, style } from "../styles/styleCode";
 
@@ -39,17 +39,23 @@ const StyledWrapper = styled.div`
 `;
 
 export default function ChartResult({ data }) {
-  const totalRunTime = data ? String(data[data.length - 1].timeStamp) : "";
-  const maxMemory = data
-    ? data.reduce((prev, current) =>
-        prev.usedMemory > current.usedMemory ? prev : current,
-      ).usedMemory
-    : "";
-  const minMemory = data
-    ? data.reduce((prev, current) =>
-        prev.usedMemory < current.usedMemory ? prev : current,
-      ).usedMemory
-    : "";
+  const [RunTime, setRunTime] = useState();
+  const [maxMemory, setmaxMemory] = useState();
+  const [minMemory, setminMemory] = useState();
+  const [nodeCount, setnodeCount] = useState();
+
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+
+    if (data.result.length > 0) {
+      setRunTime(Number(data.result.at(-1).timeStamp));
+      setmaxMemory(data.result.maxMemoryText);
+      setminMemory(data.result.minMemoryText);
+      setnodeCount(data.result.length);
+    }
+  }, [data]);
 
   return (
     <StyledWrapper>
@@ -57,7 +63,9 @@ export default function ChartResult({ data }) {
         <li className="title">RESULT</li>
         <li className="info">
           <div className="name">TOTAL RUN TIME</div>
-          <div className="data">{totalRunTime} ns</div>
+          <div className="data">
+            {RunTime}ns, {Math.round(RunTime / 1000000)}ms
+          </div>
         </li>
         <li className="info">
           <div className="name">MAX MEMORY</div>
@@ -66,6 +74,10 @@ export default function ChartResult({ data }) {
         <li className="info">
           <div className="name">MIN MEMORY</div>
           <div className="data">{minMemory}bytes</div>
+        </li>
+        <li className="info">
+          <div className="name">TOTAL NODE COUNT</div>
+          <div className="data">{nodeCount}</div>
         </li>
       </ul>
     </StyledWrapper>

--- a/src/component/ChartResult.js
+++ b/src/component/ChartResult.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import styled from "styled-components";
 import { color, style } from "../styles/styleCode";
 

--- a/src/pages/OutputResult.js
+++ b/src/pages/OutputResult.js
@@ -5,9 +5,27 @@ import ChartResult from "../component/ChartResult";
 
 export default function OutputResult() {
   const [chartData, setChartData] = useState();
+  const [chartResult, setChartResult] = useState({});
 
   const setMemoryArray = (data) => {
-    setChartData(data);
+    if (data.result.length > 0) {
+      let minMemory = Infinity;
+      let maxMemory = 0;
+
+      data.result.forEach((element) => {
+        minMemory = Math.min(minMemory, element.usedMemory);
+        maxMemory = Math.max(maxMemory, element.usedMemory);
+      });
+
+      setChartResult({
+        duration: data.result.at(-1).timeStamp - data.result.at(0).timeStamp,
+        minMemory: minMemory,
+        maxMemory: maxMemory,
+        count: data.result.length,
+      });
+
+      setChartData(data);
+    }
   };
 
   useEffect(() => {
@@ -17,7 +35,7 @@ export default function OutputResult() {
   return (
     <>
       <Chart data={chartData} />
-      <ChartResult data={chartData} />
+      <ChartResult resultData={chartResult} />
     </>
   );
 }

--- a/src/pages/OutputResult.js
+++ b/src/pages/OutputResult.js
@@ -2,13 +2,16 @@ import React, { useState, useEffect } from "react";
 
 import Chart from "../component/Chart";
 import ChartResult from "../component/ChartResult";
-import { chartMock } from "../mock/chartMock";
 
 export default function OutputResult() {
   const [chartData, setChartData] = useState();
 
+  const setMemoryArray = (data) => {
+    setChartData(data);
+  };
+
   useEffect(() => {
-    setChartData(chartMock);
+    window.electronAPI.executeHeapTrackerReply(setMemoryArray);
   }, []);
 
   return (

--- a/src/utils/codeParser.js
+++ b/src/utils/codeParser.js
@@ -68,7 +68,6 @@ module.exports = class modifyCode {
             node.end + 1,
             node.start,
           );
-
           break;
       }
     };

--- a/src/utils/codeParser.js
+++ b/src/utils/codeParser.js
@@ -34,6 +34,45 @@ module.exports = class modifyCode {
       this.lastFindNodeType(node, node.type);
     };
 
+    this.findNodeType = (node, type) => {
+      switch (type) {
+        case "ForStatement":
+        case "WhileStatement":
+        case "DoWhileStatement":
+        case "SwitchStatement":
+        case "ForOfStatement":
+          this.code = this.insertCodeType(this.code, node.start, type);
+          break;
+        case "FunctionDeclaration":
+        case "ArrowFunctionExpression":
+          if (node.body) {
+            this.code = this.insertCodeType(
+              this.code,
+              node.body.start + 1,
+              type + " " + (node.id ? node.id.name : ""),
+            );
+          }
+          break;
+      }
+    };
+
+    this.lastFindNodeType = (node, type) => {
+      switch (type) {
+        case "VariableDeclarator":
+          if (node.init.type === "ArrowFunctionExpression") {
+            this.parseNodeObject(node.init);
+          }
+
+          this.code = this.insertCodePosition(
+            this.code,
+            node.end + 1,
+            node.start,
+          );
+
+          break;
+      }
+    };
+
     this.insertCodePosition = (code, insertPosition, nodePosition) => {
       const trackingFunctionCode = `m(${nodePosition}, null);`;
 
@@ -58,29 +97,6 @@ module.exports = class modifyCode {
       this.insertLength += trackingFunctionCode.length;
 
       return modifiedCode;
-    };
-
-    this.findNodeType = (node, type) => {
-      switch (type) {
-        case "ForStatement":
-        case "WhileStatement":
-        case "DoWhileStatement":
-        case "SwitchStatement":
-          this.code = this.insertCodeType(this.code, node.start, type);
-          break;
-      }
-    };
-
-    this.lastFindNodeType = (node, type) => {
-      switch (type) {
-        case "VariableDeclarator":
-          this.code = this.insertCodePosition(
-            this.code,
-            node.end + 1,
-            node.start,
-          );
-          break;
-      }
     };
   }
 

--- a/src/utils/msChart.js
+++ b/src/utils/msChart.js
@@ -18,7 +18,7 @@ export default class LineChart {
     this.chartWidth = this.canvasWidth - Y_PADDING;
     this.chartHeight = this.canvasHeight - X_PADDING - TOP_PADDING;
 
-    this.chartDurationTime = durationTime; // 재생 시간
+    this.chartDurationTime = durationTime;
     this.excuteDurationTime = 0;
     this.intervalID = 0;
     this.currentPosition = 0;
@@ -47,7 +47,7 @@ export default class LineChart {
       }
     });
 
-    this.parseMemoryArray(); // heightPixelWeights 얻기
+    this.parseMemoryArray();
     return this;
   }
 
@@ -108,18 +108,14 @@ export default class LineChart {
     }
   };
 
-  //차트를 그리는 함수
   drawChart = () => {
     const { ctx, canvasWidth, canvasHeight, chartHeight, chartWidth } = this;
 
-    //이전에 그려진 함수를 제거하는 로직(동적인 움직임을 위해)
     ctx.clearRect(0, 0, canvasWidth, canvasHeight);
 
-    //데이터를 그리기 시작
     ctx.beginPath();
     ctx.moveTo(Y_PADDING, TOP_PADDING);
 
-    //draw Y
     ctx.lineTo(Y_PADDING, chartHeight + TOP_PADDING);
     const yInterval =
       (this.maxMemoryText - this.minMemoryText) / (Y_TICK_COUNT - 1);

--- a/src/utils/msChart.js
+++ b/src/utils/msChart.js
@@ -48,8 +48,6 @@ export default class LineChart {
     });
 
     this.parseMemoryArray(); // heightPixelWeights 얻기
-    data.maxMemoryText = this.maxMemoryText;
-    data.minMemoryText = this.minMemoryText;
     return this;
   }
 
@@ -157,8 +155,6 @@ export default class LineChart {
         ctx.lineTo(xPosition, yPosition);
         ctx.stroke();
         ctx.save();
-
-        console.log("yPosition", yPosition);
 
         this.circle.push(
           new Circle(xPosition, yPosition, NODE_RADIUS, ctx, item),

--- a/src/utils/msChart.js
+++ b/src/utils/msChart.js
@@ -1,49 +1,15 @@
 import Circle from "./circle";
 
-//축
 const X_PADDING = 25;
 const Y_PADDING = 50;
 const TOP_PADDING = 15;
-const VIEW_NODE_COUNT = 10;
-const Y_TICK_COUNT = 5;
+const VIEW_NODE_COUNT = 13;
+const Y_TICK_COUNT = 7;
 const NODE_RADIUS = 5;
 
 export default class LineChart {
-  constructor(id, durationTime) {
-    this.data = [
-      { timestamp: 1678950904231, memory: 26.470917318911535 },
-      { timestamp: 1678950904232, memory: 94.43471793706901 },
-      { timestamp: 1678950904233, memory: 26.309072289398273 },
-      { timestamp: 1678950904234, memory: 49.17418730834109 },
-      { timestamp: 1678950904235, memory: 31.160896341071865 },
-      { timestamp: 1678950904236, memory: 10.269190763446655 },
-      { timestamp: 1678950904237, memory: 73.7156142120452 },
-      { timestamp: 1678950904238, memory: 26.955150253575553 },
-      { timestamp: 1678950904239, memory: 12.170802365140121 },
-      { timestamp: 1678950904240, memory: 98.04970776474728 },
-      { timestamp: 1678950904241, memory: 5.113529099409275 },
-      { timestamp: 1678950904242, memory: 58.346443031677595 },
-      { timestamp: 1678950904243, memory: 32.87095783395879 },
-      { timestamp: 1678950904244, memory: 99.23909006003522 },
-      { timestamp: 1678950904245, memory: 54.654480598596344 },
-      { timestamp: 1678950904246, memory: 49.17418730834109 },
-      { timestamp: 1678950904247, memory: 31.160896341071865 },
-      { timestamp: 1678950904248, memory: 10.269190763446655 },
-      { timestamp: 1678950904249, memory: 73.7156142120452 },
-      { timestamp: 1678950904250, memory: 26.955150253575553 },
-      { timestamp: 1678950904251, memory: 94.43471793706901 },
-      { timestamp: 1678950904252, memory: 26.309072289398273 },
-      { timestamp: 1678950904253, memory: 49.17418730834109 },
-      { timestamp: 1678950904254, memory: 31.160896341071865 },
-      { timestamp: 1678950904255, memory: 10.269190763446655 },
-      { timestamp: 1678950904256, memory: 73.7156142120452 },
-      { timestamp: 1678950904257, memory: 58.346443031677595 },
-      { timestamp: 1678950904258, memory: 32.87095783395879 },
-      { timestamp: 1678950904259, memory: 99.23909006003522 },
-      { timestamp: 1678950904250, memory: 54.654480598596344 },
-      { timestamp: 1678950904261, memory: 49.17418730834109 },
-    ];
-
+  constructor(id, data, durationTime) {
+    this.data = data;
     this.canvas = document.getElementById(id);
     this.ctx = this.canvas.getContext("2d");
 
@@ -52,16 +18,19 @@ export default class LineChart {
     this.chartWidth = this.canvasWidth - Y_PADDING;
     this.chartHeight = this.canvasHeight - X_PADDING - TOP_PADDING;
 
-    this.durationTime = durationTime; // 재생 시간
-    this.intervalID = 0; // 다시 그리기 interval ID
-    this.currentPosition = 0; // 차트 그리기 기준 배열 인덱스
+    this.chartDurationTime = durationTime; // 재생 시간
+    this.excuteDurationTime = 0;
+    this.intervalID = 0;
+    this.currentPosition = 0;
 
-    this.maxMemoryValue = 0; // value 최대값
-    this.minMemoryValue = Infinity; // value 최소값
-    this.maxTimeValue = 0; // Time 최대값
-    this.minTimeValue = Infinity; // Time 최소값
-    this.heightPixelWeights = 0; // 높이 1 pixel 에 value 표현 가중치
-    this.widthPixelWeights = 0; // 너비 1 pixel에 time 표현 가중치
+    this.maxMemoryText = 0;
+    this.minMemoryText = Infinity;
+    this.maxMemoryValue = 0;
+    this.minMemoryValue = Infinity;
+    this.maxTimeValue = 0;
+    this.minTimeValue = Infinity;
+    this.heightPixelWeights = 0;
+    this.widthPixelWeights = 0;
 
     this.circle = [];
 
@@ -79,7 +48,8 @@ export default class LineChart {
     });
 
     this.parseMemoryArray(); // heightPixelWeights 얻기
-
+    data.maxMemoryText = this.maxMemoryText;
+    data.minMemoryText = this.minMemoryText;
     return this;
   }
 
@@ -87,11 +57,12 @@ export default class LineChart {
     if (this.intervalID < 1) {
       this.intervalID = setInterval(() => {
         this.updateData();
-      }, this.durationTime / (this.data.at(-1).timestamp - this.data.at(0).timestamp));
+      }, this.chartDurationTime / this.excuteDurationTime);
     }
   };
 
   pause = () => {
+    this.circle.every((item) => item.draw());
     clearInterval(this.intervalID);
     this.intervalID = 0;
   };
@@ -102,19 +73,35 @@ export default class LineChart {
     this.currentPosition = 0;
   };
 
-  //시간을 실시간으로 세팅하는 함수
   setTime = () => {
-    this.startTime = this.data[0].timestamp;
+    this.startTime = this.data[0].timeStamp;
     this.intervalID = setInterval(() => {
       this.updateData();
-    }, this.durationTime / (this.data.at(-1).timestamp - this.data.at(0).timestamp));
+    }, this.chartDurationTime / this.excuteDurationTime);
   };
 
   parseMemoryArray = () => {
     if (this.data.length) {
+      const baseTime = this.data[0].timeStamp;
+      const baseMemory = this.data[0].usedMemory;
+
       this.data.forEach((item) => {
-        this.minMemoryValue = Math.min(this.minMemoryValue, item.memory);
-        this.maxMemoryValue = Math.max(this.maxMemoryValue, item.memory);
+        this.minMemoryText = Math.min(this.minMemoryText, item.usedMemory);
+        this.maxMemoryText = Math.max(this.maxMemoryText, item.usedMemory);
+      });
+
+      this.data = this.data.map((item) => {
+        item.timeStamp = item.timeStamp - baseTime;
+        item.memGap = item.usedMemory - baseMemory;
+        item.usedMemory = (item.usedMemory - this.minMemoryText) / 100;
+        return item;
+      });
+
+      this.excuteDurationTime = this.data.length;
+
+      this.data.forEach((item) => {
+        this.minMemoryValue = Math.min(this.minMemoryValue, item.usedMemory);
+        this.maxMemoryValue = Math.max(this.maxMemoryValue, item.usedMemory);
       });
 
       this.heightPixelWeights =
@@ -137,32 +124,25 @@ export default class LineChart {
     //draw Y
     ctx.lineTo(Y_PADDING, chartHeight + TOP_PADDING);
     const yInterval =
-      (this.maxMemoryValue - this.minMemoryValue) / (Y_TICK_COUNT - 1);
+      (this.maxMemoryText - this.minMemoryText) / (Y_TICK_COUNT - 1);
     ctx.textAlign = "right";
     ctx.textBaseline = "middle";
+
     for (let i = 0; i < Y_TICK_COUNT; i++) {
-      const value = Math.floor(i * yInterval + this.minMemoryValue);
+      const value = Math.floor(i * yInterval + this.minMemoryText);
       const yPoint =
         TOP_PADDING + chartHeight - i * (chartHeight / Y_TICK_COUNT);
       ctx.fillText(value, Y_PADDING - 3, yPoint);
     }
 
-    //draw X
     ctx.lineTo(canvasWidth, chartHeight + TOP_PADDING);
     ctx.stroke();
 
-    // 차트 안 데이터만 보이게 하는 로직 -> store과 연관된다.
-    // x축과 y축이 시작되는 곳이 위치가 된다.
     ctx.save();
     ctx.beginPath();
     ctx.rect(Y_PADDING, 0, chartWidth, canvasHeight);
     ctx.clip();
 
-    // 데이터를 그리는 로직
-    // 1. 새로 패스를 그린다고 선언한다.
-    // 2. data(배열)을 돌면서 x의 위치와 y의 위치를 생성
-    // 3. data가 없다면? -> 해당 좌표에 시작할 수 있도록 좌표를 옮김
-    // 4. data가 있다면? -> x의 위치와 y의 위치를 기반으로 라인을 그림
     ctx.beginPath();
 
     this.data
@@ -172,30 +152,27 @@ export default class LineChart {
         const yPosition =
           TOP_PADDING +
           this.chartHeight -
-          this.heightPixelWeights * item.memory;
+          this.heightPixelWeights * item.usedMemory;
 
         ctx.lineTo(xPosition, yPosition);
         ctx.stroke();
         ctx.save();
 
+        console.log("yPosition", yPosition);
+
         this.circle.push(
-          new Circle(xPosition, yPosition, NODE_RADIUS, ctx, item).draw(),
+          new Circle(xPosition, yPosition, NODE_RADIUS, ctx, item),
         );
 
         ctx.moveTo(xPosition, yPosition);
 
         ctx.fillStyle = "black";
-        ctx.fillText(
-          new Date(item.timestamp).getMilliseconds(),
-          xPosition,
-          chartHeight + TOP_PADDING + 4,
-        );
+        ctx.fillText(item.timeStamp, xPosition, chartHeight + TOP_PADDING + 4);
       });
     ctx.stroke();
     ctx.restore();
   };
 
-  //데이터를 갱신하는 함수
   updateData = () => {
     if (!this.data.length) {
       return;
@@ -207,6 +184,8 @@ export default class LineChart {
 
     if (this.currentPosition - VIEW_NODE_COUNT / 2 > this.data.length) {
       clearInterval(this.intervalID);
+      this.intervalID = 0;
+      this.currentPosition = 0;
     }
   };
 }


### PR DESCRIPTION
## ✔️PR타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능추가
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ✔️개요

- 메모리 추적 결과 배열을 결과 컴포넌트에 전달 하기위해서 chart 컴포넌트에서 받는 위치는 상위 컴포넌트 `userEditor.js`로 수정했습니다.
- 메모리추적 함수 삽입 타입에 **함수**, **화살표함수**, **for of** 를 추가하여 더 상세한 정보를 얻을 수 있도록 했습니다.
- mock 데이터로 0~99 까지 반영되던 y좌표의 값을 실제로 넘겨받는 `process.memoryUsage()`의 값으로 적용하였습니다.

## ✔️변경사항

- 주요 모듈들이 작업이 완료되기 전까지 사용하던 mock 데이터로 0~99 까지 반영되던 y좌표의 값을 실제로 넘겨받는 `process.memoryUsage()`의 값으로 적용하였습니다.

- 메모리추적 함수 삽입 타입에 **함수**, **화살표함수**, **for of** 를 추가하여 더 상세한 정보를 얻을 수 있도록 했습니다.

## ✔️스크린샷
![스크린샷 2023-03-20 오후 12 12 06](https://user-images.githubusercontent.com/52302090/226238028-28a9fed8-2c6b-4d58-8ae9-bd72c3fc5e26.png)


## ✔️리뷰어들한테

<br>
<br>
<br>
