### PR TITLE
feat: x 축 시간 단위 변경 및 데이터 시간간격 차이에 따른 노드 생성 표현

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,7 @@
     "ecmaVersion": "latest"
   },
   "env": {
-    "es6": true
+    "es2020": true
   },
   "extends": ["react-app", "eslint:recommended"],
   "rules": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
   "rules": {
     "no-var": "error",
     "no-multiple-empty-lines": "error",
+    "no-console": ["error", { "allow": ["warn", "error", "info"] }],
     "eqeqeq": "error",
     "no-unused-vars": "warn"
   }

--- a/src/utils/msChart.js
+++ b/src/utils/msChart.js
@@ -110,6 +110,8 @@ export default class LineChart {
 
   drawChart = () => {
     const { ctx, canvasWidth, canvasHeight, chartHeight, chartWidth } = this;
+    const xDistance =
+      this.data[this.data.length - 1].timeStamp / BigInt(this.data.length);
 
     ctx.clearRect(0, 0, canvasWidth, canvasHeight);
 
@@ -157,12 +159,19 @@ export default class LineChart {
         );
 
         ctx.moveTo(xPosition, yPosition);
-
-        ctx.fillStyle = "black";
-        ctx.fillText(item.timeStamp, xPosition, chartHeight + TOP_PADDING + 4);
       });
     ctx.stroke();
     ctx.restore();
+
+    for (let index = 0; index < VIEW_NODE_COUNT; index += 1) {
+      const xPosition = (this.chartWidth / VIEW_NODE_COUNT) * (index + 1);
+
+      ctx.fillText(
+        xDistance * BigInt(this.currentPosition) + xDistance * BigInt(index),
+        xPosition,
+        chartHeight + TOP_PADDING + 10,
+      );
+    }
   };
 
   updateData = () => {


### PR DESCRIPTION
## ✔️PR타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능추가
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ✔️개요

- ESlint 수정
- x축의 단위를 ms에서 ns로 변경.
- 노드와 x축 텍스트를 같이 그리는 로직 분리.
- 노드간 시간간격 차이를 차트에 표현되게 로직을 수정 구현.

## ✔️변경사항

- `BigInt()`메서드의 사용을 위해 `.eslintrc` 파일의 `env`를 `"es6": true"`에서 `"es2020": true`로 변경하였습니다.
- 회의를 통해 `console.log`를 방지하는 ESlint rule을 추가하였습니다.
- x축 텍스트의 단위를 기존 목데이터의 ms시간단위를 실제 사용되는 시간데이터의 단위인 ns로 사용하기 위해서 변경하였습니다.
- 기존 코드에서 노드와 x축 텍스트를 같이 그리는 로직을 시간간격 차이에 따라 노드 간격의 차이를 두기 위해서 따로 분리하였습니다.

- 노드 간격 차이를 구한 방법을 아래와 같습니다.
1. setInterval로 한 장면에 표시되는 시간값의 범위가 있을것이라고 생각.
2. 시간값의 범위에 있는 데이터를 필터링.
3. 필터링한 데이터를 사용하여 Circle 인스턴스를 만들고 `this.snapshotCircle`에 저장
4. `this.snapshotCircle`을 순회하면서 노드를 차트에 생성
5. `drawChart`코드가 완료되면 x축을 왼쪽으로 한칸씩 옮기면서 위 과정 반복



## ✔️스크린샷

<img width="533" alt="스크린샷 2023-03-20 오후 8 51 46" src="https://user-images.githubusercontent.com/107802867/226331391-1ee8c488-d1ba-4445-b0c7-5d31975e8bff.png">

## ✔️리뷰어들한테

1. `BigInt()`를 사용한 이유는 데이터의 `timeStamp`가 BinInt이기 때문에 `Bigint type`과 `number type`을 연산하기 위해서 사용하였습니다.
2. `xDistance`라는 변수명은 코드의 실행시간에서 데이터 배열의 길이를 나눈 값으로 적당한 x축 텍스트의 간격을 표현하기 위해서 만들어졌습니다. 혹시 더 좋은 변수명이 있다면 의견 달아주시면 감사하겠습니다.
3. 제가 올린 코드를 최대한 상수화 하여 push 하였는데, 더욱 상수로 표시할수 있는 값이 있으면 같이 의견을 나누고 싶습니다.
4. 노드의 y축의 값이 작아 x축에 겹치는 현상이 있습니다.
5. 기존 차트그리기 로직을 제거 후 x축 값이 예상되는 범위를 벗어나는 현상이 있습니다. 아래 중 어느 부분이 이러한 현상을 일으키는지 같이 생각해주시면 감사하겠습니다.
```js
this.data
      .slice(this.currentPosition, this.currentPosition + VIEW_NODE_COUNT)
      .forEach((item, index) => {
        const xPosition = (this.chartWidth / VIEW_NODE_COUNT) * (index + 1);
        const yPosition =
          TOP_PADDING +
          this.chartHeight -
          this.heightPixelWeights * item.usedMemory;

        ctx.lineTo(xPosition, yPosition);
        ctx.stroke();
        ctx.save();

        ctx.moveTo(xPosition, yPosition);
      });

```