### PR TITLE
feat: 차트 노드들 연결하여 라인차트 구현 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@
   "rules": {
     "no-var": "error",
     "no-multiple-empty-lines": "error",
-    "no-console": ["error", { "allow": ["warn", "error", "info"] }],
+    // "no-console": ["error", { "allow": ["warn", "error", "info"] }],
     "eqeqeq": "error",
     "no-unused-vars": "warn"
   }

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@
   "rules": {
     "no-var": "error",
     "no-multiple-empty-lines": "error",
-    // "no-console": ["error", { "allow": ["warn", "error", "info"] }],
+    "no-console": ["warn", { "allow": ["warn", "error", "info"] }],
     "eqeqeq": "error",
     "no-unused-vars": "warn"
   }

--- a/src/component/Chart.js
+++ b/src/component/Chart.js
@@ -3,7 +3,7 @@ import LineChart from "../utils/msChart";
 import styled from "styled-components";
 import { color, style } from "../styles/styleCode";
 
-const CHART_DURATION_TIME = 6000;
+const CHART_DURATION_TIME = 30000;
 
 const Button = styled.button`
   display: flex;

--- a/src/utils/msChart.js
+++ b/src/utils/msChart.js
@@ -6,7 +6,7 @@ const Y_PADDING = 50;
 const TOP_PADDING = 15;
 const VIEW_NODE_COUNT = 13;
 const Y_TICK_COUNT = 7;
-const NODE_RADIUS = 5;
+const NODE_RADIUS = 2;
 
 export default class LineChart {
   constructor(id, data, durationTime) {
@@ -36,12 +36,15 @@ export default class LineChart {
     this.circle = [];
     this.snapshotCircle = [];
 
-    // node 모달 창 생성
     this.canvas.addEventListener("mousemove", (e) => {
       const cursorPositionX = e.clientX - this.ctx.canvas.offsetLeft;
       const cursorPositionY = e.clientY - this.ctx.canvas.offsetTop;
 
-      if (this.snapshotCircle.length > 0) {
+      if (
+        this.snapshotCircle.length > 0 &&
+        cursorPositionX > Y_PADDING &&
+        cursorPositionY < this.chartHeight + TOP_PADDING
+      ) {
         this.snapshotCircle.forEach((item) => {
           if (item.isMouseOver(cursorPositionX, cursorPositionY)) {
             const modal = document.getElementById(`${item.modal.id}`);
@@ -62,7 +65,6 @@ export default class LineChart {
         });
       }
     });
-    // heightPixelWeights 얻기
     this.parseMemoryArray();
 
     return this;
@@ -152,39 +154,44 @@ export default class LineChart {
     ctx.stroke();
 
     /* Y축 좌측으로 노드가
-    그려지지 않게 해당 부분을 가림 */
+    그려지지 않게 함 */
     ctx.save();
     ctx.beginPath();
     ctx.rect(Y_PADDING, 0, chartWidth, canvasHeight);
     ctx.clip();
 
-    /* 동적으로 움직이는 차트 내
-    한 장면의 노드 개수만큼 Circle 객체 생성 */
-    const offset = 25;
-    this.snapshotCircle = this.data
-      .filter(
-        (item) =>
-          item.timeStamp > xDistance * BigInt(this.currentPosition - offset) &&
-          item.timeStamp <
-            xDistance * BigInt(this.currentPosition + VIEW_NODE_COUNT + offset),
-      )
-      .map((item) => {
-        const xPosition =
-          (this.chartWidth / (Number(xDistance) * VIEW_NODE_COUNT)) *
-            Number(item.timeStamp) -
-          (this.chartWidth / VIEW_NODE_COUNT) * this.currentPosition +
-          offset;
-        const yPosition =
-          TOP_PADDING +
-          this.chartHeight -
-          this.heightPixelWeights * item.usedMemory;
+    const createCircleInChart = () => {
+      const offset = 25;
+      const merginNode = 5;
+      this.snapshotCircle = this.data
+        .filter(
+          (item) =>
+            item.timeStamp >
+              xDistance * BigInt(this.currentPosition - merginNode) &&
+            item.timeStamp <
+              xDistance *
+                BigInt(this.currentPosition + VIEW_NODE_COUNT + merginNode),
+        )
+        .map((item) => {
+          const xPosition =
+            (this.chartWidth / (Number(xDistance) * VIEW_NODE_COUNT)) *
+              Number(item.timeStamp) -
+            (this.chartWidth / VIEW_NODE_COUNT) * this.currentPosition +
+            offset;
+          const yPosition =
+            TOP_PADDING +
+            this.chartHeight -
+            this.heightPixelWeights * item.usedMemory;
 
-        return new Circle(xPosition, yPosition, NODE_RADIUS, ctx, item);
-      });
+          return new Circle(xPosition, yPosition, NODE_RADIUS, ctx, item);
+        });
+    };
+    createCircleInChart();
 
-    // 동적으로 움직이는 한 장면에 노드를 표현하였습니다.
-    // FIXME: 노드가 x축과 겹치는 현상 해결 필요.
     ctx.beginPath();
+
+    /* 노드들을 연결하는 선 */
+    // FIXME: 노드가 x축과 겹치는 현상 해결 필요
     this.snapshotCircle.forEach((item, index) => {
       const xPosition = item.x;
       const yPosition = item.y;
@@ -197,7 +204,7 @@ export default class LineChart {
       item.draw(color.chartDot);
     });
 
-    // x축 좌표 ns 표현
+    /* x축 좌표 ns 표현 */
     for (let index = 0; index < VIEW_NODE_COUNT; index += 1) {
       const xPosition = (this.chartWidth / VIEW_NODE_COUNT) * (index + 1);
 
@@ -210,7 +217,6 @@ export default class LineChart {
       );
     }
 
-    // FIXME: Circle method인 reDraw()로 인한 색변경 오류 발견. 해결 필요
     ctx.stroke();
     ctx.restore();
   };

--- a/src/utils/msChart.js
+++ b/src/utils/msChart.js
@@ -36,6 +36,7 @@ export default class LineChart {
     this.circle = [];
     this.snapshotCircle = [];
 
+    // node 모달 창 생성
     this.canvas.addEventListener("mousemove", (e) => {
       const cursorPositionX = e.clientX - this.ctx.canvas.offsetLeft;
       const cursorPositionY = e.clientY - this.ctx.canvas.offsetTop;
@@ -61,8 +62,8 @@ export default class LineChart {
         });
       }
     });
-
-    this.parseMemoryArray(); // heightPixelWeights 얻기
+    // heightPixelWeights 얻기
+    this.parseMemoryArray();
 
     return this;
   }
@@ -133,8 +134,8 @@ export default class LineChart {
 
     ctx.beginPath();
     ctx.moveTo(Y_PADDING, TOP_PADDING);
-
     ctx.lineTo(Y_PADDING, chartHeight + TOP_PADDING);
+
     const yInterval =
       (this.maxMemoryText - this.minMemoryText) / (Y_TICK_COUNT - 1);
     ctx.textAlign = "right";
@@ -150,24 +151,24 @@ export default class LineChart {
     ctx.lineTo(canvasWidth, chartHeight + TOP_PADDING);
     ctx.stroke();
 
+    /* Y축 좌측으로 노드가
+    그려지지 않게 해당 부분을 가림 */
     ctx.save();
     ctx.beginPath();
     ctx.rect(Y_PADDING, 0, chartWidth, canvasHeight);
     ctx.clip();
 
-    ctx.beginPath();
-
-    // 동적으로 움직이는 차트내 한 장면의 노드 갯수를 filter하고
-    // map으로 Circle객체를 생성하고 저장하였습니다.
+    /* 동적으로 움직이는 차트 내
+    한 장면의 노드 개수만큼 Circle 객체 생성 */
+    const offset = 25;
     this.snapshotCircle = this.data
       .filter(
         (item) =>
-          item.timeStamp > xDistance * BigInt(this.currentPosition) &&
+          item.timeStamp > xDistance * BigInt(this.currentPosition - offset) &&
           item.timeStamp <
-            xDistance * BigInt(this.currentPosition + VIEW_NODE_COUNT),
+            xDistance * BigInt(this.currentPosition + VIEW_NODE_COUNT + offset),
       )
       .map((item) => {
-        const offset = 25;
         const xPosition =
           (this.chartWidth / (Number(xDistance) * VIEW_NODE_COUNT)) *
             Number(item.timeStamp) -
@@ -183,7 +184,16 @@ export default class LineChart {
 
     // 동적으로 움직이는 한 장면에 노드를 표현하였습니다.
     // FIXME: 노드가 x축과 겹치는 현상 해결 필요.
-    this.snapshotCircle.forEach((item) => {
+    ctx.beginPath();
+    this.snapshotCircle.forEach((item, index) => {
+      const xPosition = item.x;
+      const yPosition = item.y;
+
+      ctx.lineTo(xPosition, yPosition);
+      ctx.stroke();
+      ctx.save();
+
+      ctx.moveTo(xPosition, yPosition);
       item.draw(color.chartDot);
     });
 


### PR DESCRIPTION
## 🔹 PR type(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능추가
- [x] 버그 수정
- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🔹 Summary

- feat: 차트의 노드와 노드를 연결하여 라인차트를 구현하였습니다.
- fix: 차트 이외의 영역에 `hover` 이벤트 시 모달창이 생기는 문제를 해결하였습니다

## 🔹 Description

- 차트의 노드와 노드를 연결하여 라인차트를 구현하였습니다.
    해당 내용은 주석이 달려 있습니다. 혹 문제가 있다면 말씀해주세요.
    [라인차트 구현](https://github.com/CODEBLUE3/HeapTracker-client/compare/feat/chart-node-line?expand=1#diff-f5c14b2041c63ed2d57b9cd685b539407455ed3077be3afda3cb4be9e71cf7cbR191-R200)

- 오프셋 조절
    기존의 `this.snapshotCircle` `map` 함수 내 `offset`을 상단 변수로 빼고, 해당 변수를 같이 공유해서 사용하였습니다.
    `offset`을 주지 않고 화면에 보이는 노드 개수 만큼 원을 만들어 표현하니, 
    화면에 보이지 않는 부분은 선도 그려지지 않는 문제가 생겼습니다.
    해당 `offset`으로 범위 확장하여 노드를 더 그리되, 차트 외부를 벗어나 없는 것처럼 표현하였습니다.


## 🔹 Issues

- 차트 외 보이지 않은 노드에 `hover` 이벤트 가능 및 모달창 생성
    노드 개수를 차트 내 보이는 것보다 더 가져와 그리니, 외부에 보이지는 않지만 존재하는 노드로 인해
    허공에 `hover` 이벤트가 생성되는 것을 확인하였습니다.
    이는 차트 내 부분에서만 이벤트가 생성될 수 있도록 범위 조절로 해결하였습니다.
    [해당 부분](https://github.com/CODEBLUE3/HeapTracker-client/compare/feat/chart-node-line?expand=1#diff-f5c14b2041c63ed2d57b9cd685b539407455ed3077be3afda3cb4be9e71cf7cbR44-R48) 


## 🔹 Screenshot
<img width="478" alt="스크린샷 2023-03-21 오후 7 51 59" src="https://user-images.githubusercontent.com/62285847/226585205-49b54bce-61ab-4349-a215-dd912534dfe2.png">

## 🔹 To Reviewer
- msChart.js 내 주석을 변경하였습니다 확인 부탁드립니다.
- 리뷰 감사합니다. 
