### PR TITLE
fix: 차트 내 노드들이 연결되지 않는 문제 해결

### DIFF
--- a/src/utils/msChart.js
+++ b/src/utils/msChart.js
@@ -152,6 +152,8 @@ export default class LineChart {
     ctx.rect(Y_PADDING, 0, chartWidth, canvasHeight);
     ctx.clip();
 
+    ctx.beginPath();
+
     const createCircleInChart = () => {
       const offset = 25;
       const merginNode = 5;
@@ -159,52 +161,27 @@ export default class LineChart {
         .filter(
           (item) =>
             item.timeStamp >
-              xDistance * BigInt(this.currentPosition - merginNode) &&
+              this.xDistance * (this.currentPosition - merginNode) &&
             item.timeStamp <
-              xDistance *
-                BigInt(this.currentPosition + VIEW_NODE_COUNT + merginNode),
+              this.xDistance *
+                (this.currentPosition + VIEW_NODE_COUNT + merginNode),
         )
         .map((item) => {
           const xPosition =
-            (this.chartWidth / (Number(xDistance) * VIEW_NODE_COUNT)) *
-              Number(item.timeStamp) -
+            (this.chartWidth / (this.xDistance * VIEW_NODE_COUNT)) *
+              item.timeStamp -
             (this.chartWidth / VIEW_NODE_COUNT) * this.currentPosition +
             offset;
           const yPosition =
             TOP_PADDING +
             this.chartHeight -
-            this.heightPixelWeights * item.usedMemory;
+            this.heightPixelWeights * (item.usedMemory - this.baseMemory);
 
           return new Circle(xPosition, yPosition, NODE_RADIUS, ctx, item);
         });
     };
+
     createCircleInChart();
-
-    ctx.beginPath();
-
-    // 동적으로 움직이는 차트내 한 장면의 노드 갯수를 filter하고
-    // map으로 Circle객체를 생성하고 저장하였습니다.
-    this.snapshotCircle = this.data
-      .filter(
-        (item) =>
-          item.timeStamp > this.xDistance * this.currentPosition &&
-          item.timeStamp <
-            this.xDistance * (this.currentPosition + VIEW_NODE_COUNT),
-      )
-      .map((item) => {
-        const offset = 25;
-        const xPosition =
-          (this.chartWidth / (this.xDistance * VIEW_NODE_COUNT)) *
-            item.timeStamp -
-          (this.chartWidth / VIEW_NODE_COUNT) * this.currentPosition +
-          offset;
-        const yPosition =
-          TOP_PADDING +
-          this.chartHeight -
-          this.heightPixelWeights * (item.usedMemory - this.baseMemory);
-
-        return new Circle(xPosition, yPosition, NODE_RADIUS, ctx, item);
-      });
 
     /* 노드들을 연결하는 선 */
     // FIXME: 노드가 x축과 겹치는 현상 해결 필요


### PR DESCRIPTION
## 🔹 PR type(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능추가
- [x] 버그 수정
- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🔹 Summary

- 차트 내 노드들이 차트 바깥으로 나가면 연결 선이 보이지 않는 문제가 생겼습니다.
- `conflict`을 해결하는 과정에서 해당 함수가 두개 다 `merge`된 문제로 이를 해결하였습니다.

## 🔹 Description

- 차트 내 노드들이 차트 바깥으로 나가면, 연결선이 보이지 않는 문제가 생겼습니다.
  이러면 라인 차트가 끝까지 연결된 것처럼 보이는 것이 아닌 공중에 뜬 것처럼 보입니다.
  
  문제의 원인은 `conflict`를 해결하는 과정에서 차트의 노드를 그리는 함수가 두번 반복 된 것이 이유였습니다.
  이 중 하나의 함수를 제거하였습니다.

## 🔹 Issues

## 🔹 Screenshot

## 🔹 To Reviewer
- 리뷰 잘 부탁드립니다.
