### PR TITLE
refact: chart modal 컴포넌트 변경 

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,12 +1,14 @@
 import { configureStore } from "@reduxjs/toolkit";
 import heapMemoryReducer from "../features/heapMemory/heapMemorySlice";
 import userCodeReducer from "../features/userCode/userCodeSlice";
+import chartModalReducer from "../features/chartModal/chartModalSlice";
 import logger from "redux-logger";
 
 export const store = configureStore({
   reducer: {
     heapMemory: heapMemoryReducer,
     userCode: userCodeReducer,
+    chartModal: chartModalReducer,
   },
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(logger),
 });

--- a/src/component/Chart.js
+++ b/src/component/Chart.js
@@ -2,7 +2,12 @@ import React, { useEffect, useState } from "react";
 import LineChart from "../utils/LineChart";
 import styled from "styled-components";
 import { color, style } from "../styles/styleCode";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
+import {
+  setChartModalData,
+  setChartModalStyle,
+  hiddenChartModal,
+} from "../features/chartModal/chartModalSlice";
 
 const CHART_DURATION_TIME = 10000;
 
@@ -28,19 +33,22 @@ const Controller = styled.div`
 
 export default function Chart() {
   const [chart, setChart] = useState();
+  const dispatch = useDispatch();
   const memoryData = useSelector(
     (state) => state.heapMemory.heapMemoryData.result,
   );
 
-  useEffect(() => {
-    if (!memoryData) return;
+  function checkNodeHover(isHover, ...node) {
+    const [data, style] = node;
 
-    chart.setData(memoryData, CHART_DURATION_TIME);
-  }, [memoryData]);
+    if (isHover) {
+      dispatch(setChartModalData(data));
+      dispatch(setChartModalStyle(style));
+      return;
+    }
 
-  useEffect(() => {
-    setChart(new LineChart("lineChart"));
-  }, []);
+    dispatch(hiddenChartModal(false));
+  }
 
   function handleChartPlay() {
     if (chart) {
@@ -59,6 +67,16 @@ export default function Chart() {
       chart.stop();
     }
   }
+
+  useEffect(() => {
+    if (!memoryData) return;
+
+    chart.setData(memoryData, CHART_DURATION_TIME);
+  }, [memoryData]);
+
+  useEffect(() => {
+    setChart(new LineChart("lineChart", checkNodeHover));
+  }, []);
 
   return (
     <>

--- a/src/component/ChartModal.js
+++ b/src/component/ChartModal.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+import styled from "styled-components";
+
+const Container = styled.div`
+  visibility: hidden;
+`;
+
+export default function ChartModal() {
+  const modal = useSelector((state) => state.ChartModal);
+
+  return (
+    <Container>
+      <div className="chartModal">
+        chartModal
+        <div className="codeCount"></div>
+        <div className="codeType"></div>
+        <div className="usedMemory"></div>
+        <div className="timeStamp"></div>
+      </div>
+    </Container>
+  );
+}

--- a/src/component/ChartModal.js
+++ b/src/component/ChartModal.js
@@ -7,30 +7,49 @@ const Container = styled.div`
   visibility: ${(props) =>
     props.visibility === "true" ? "visible" : "hidden"};
   position: absolute;
+  top: ${(props) => props.top};
+  left: ${(props) => props.left};
+  padding: 10px 20px;
+
   background-color: ${color.chartModal};
   border-radius: ${style.borderRadius};
-  padding: 10px 20px;
   font-size: 1rem;
 `;
 
+const POSITION_UNIT = "px";
+const REMOVE_CODE_TYPE_ARRAY = [
+  "statement",
+  "Declaration",
+  "Expression",
+  "Statement",
+];
+
 export default function ChartModal() {
-  const {
-    codeCount,
-    codeType,
-    codePositon,
-    usedMemory,
-    timeStamp,
-    visibility,
-  } = useSelector((state) => state.chartModal);
+  const { codeCount, codeType, codePosition, usedMemory, timeStamp } =
+    useSelector((state) => state.chartModal.data);
+  const { visibility, top, left } = useSelector(
+    (state) => state.chartModal.styles,
+  );
+
+  const usTimestamp = Math.floor(Number(timeStamp)) / 1000;
+  const shortCodeType =
+    codeType &&
+    REMOVE_CODE_TYPE_ARRAY.map((type) => {
+      if (codeType.includes(type)) return codeType.replace(type, "");
+    }).filter((node) => node);
 
   return (
-    <Container visibility={String(visibility)}>
+    <Container
+      visibility={String(visibility)}
+      top={top + POSITION_UNIT}
+      left={left + POSITION_UNIT}
+    >
       <div className="codeCount">{codeCount && codeCount}th node</div>
       <div className="codeType">
-        {codeType ? `Type: ${codeType}` : `Code Position: ${codePositon}`}
+        {codeType ? `Type: ${shortCodeType}` : `Code Position: ${codePosition}`}
       </div>
       <div className="usedMemory">Used Memory: {usedMemory && usedMemory}</div>
-      <div className="timeStamp">Time: {timeStamp && timeStamp}</div>
+      <div className="timeStamp">Time: {timeStamp && usTimestamp} us</div>
     </Container>
   );
 }

--- a/src/component/ChartModal.js
+++ b/src/component/ChartModal.js
@@ -1,23 +1,36 @@
 import React from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import styled from "styled-components";
+import { color, style } from "../styles/styleCode";
 
 const Container = styled.div`
-  visibility: hidden;
+  visibility: ${(props) =>
+    props.visibility === "true" ? "visible" : "hidden"};
+  position: absolute;
+  background-color: ${color.chartModal};
+  border-radius: ${style.borderRadius};
+  padding: 10px 20px;
+  font-size: 1rem;
 `;
 
 export default function ChartModal() {
-  const modal = useSelector((state) => state.ChartModal);
+  const {
+    codeCount,
+    codeType,
+    codePositon,
+    usedMemory,
+    timeStamp,
+    visibility,
+  } = useSelector((state) => state.chartModal);
 
   return (
-    <Container>
-      <div className="chartModal">
-        chartModal
-        <div className="codeCount"></div>
-        <div className="codeType"></div>
-        <div className="usedMemory"></div>
-        <div className="timeStamp"></div>
+    <Container visibility={String(visibility)}>
+      <div className="codeCount">{codeCount && codeCount}th node</div>
+      <div className="codeType">
+        {codeType ? `Type: ${codeType}` : `Code Position: ${codePositon}`}
       </div>
+      <div className="usedMemory">Used Memory: {usedMemory && usedMemory}</div>
+      <div className="timeStamp">Time: {timeStamp && timeStamp}</div>
     </Container>
   );
 }

--- a/src/features/chartModal/chartModalSlice.js
+++ b/src/features/chartModal/chartModalSlice.js
@@ -1,0 +1,23 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  codeCount: 0,
+  codeType: "",
+  usedMemory: "",
+  timeStamp: "",
+  visibility: false,
+};
+
+export const chartModalSlice = createSlice({
+  name: "chartModal",
+  initialState,
+  reducers: {
+    setChartModal: (state, action) => {
+      state.heapMemoryData = action.payload;
+    },
+  },
+});
+
+export const { setChartModal } = chartModalSlice.actions;
+
+export default chartModalSlice.reducer;

--- a/src/features/chartModal/chartModalSlice.js
+++ b/src/features/chartModal/chartModalSlice.js
@@ -3,9 +3,10 @@ import { createSlice } from "@reduxjs/toolkit";
 const initialState = {
   codeCount: 0,
   codeType: "",
+  codePosition: "",
   usedMemory: "",
   timeStamp: "",
-  visibility: false,
+  visibility: true,
 };
 
 export const chartModalSlice = createSlice({

--- a/src/features/chartModal/chartModalSlice.js
+++ b/src/features/chartModal/chartModalSlice.js
@@ -1,24 +1,50 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
-  codeCount: 0,
-  codeType: "",
-  codePosition: "",
-  usedMemory: "",
-  timeStamp: "",
-  visibility: true,
+  data: {
+    codeCount: 0,
+    codeType: "",
+    codePosition: "",
+    usedMemory: "",
+    timeStamp: "",
+  },
+  styles: {
+    visibility: false,
+    top: 0,
+    left: 0,
+  },
 };
 
 export const chartModalSlice = createSlice({
   name: "chartModal",
   initialState,
   reducers: {
-    setChartModal: (state, action) => {
-      state.heapMemoryData = action.payload;
+    setChartModalData: (state, action) => {
+      const { codeCount, codeType, codePosition, usedMemory, timeStamp } =
+        action.payload;
+
+      state.data.codeCount = codeCount;
+      state.data.codeType = codeType;
+      state.data.codePosition = codePosition;
+      state.data.usedMemory = usedMemory;
+      state.data.timeStamp = timeStamp;
+    },
+    setChartModalStyle: (state, action) => {
+      const { visibility, top, left } = action.payload;
+
+      state.styles.visibility = visibility;
+      state.styles.top = top;
+      state.styles.left = left;
+    },
+    hiddenChartModal: (state, action) => {
+      const hidden = action.payload;
+
+      state.styles.visibility = hidden;
     },
   },
 });
 
-export const { setChartModal } = chartModalSlice.actions;
+export const { setChartModalData, setChartModalStyle, hiddenChartModal } =
+  chartModalSlice.actions;
 
 export default chartModalSlice.reducer;

--- a/src/pages/OutputResult.js
+++ b/src/pages/OutputResult.js
@@ -1,8 +1,9 @@
 import React, { useEffect } from "react";
 import { useDispatch } from "react-redux";
-
+import ChartModal from "../component/ChartModal";
 import Chart from "../component/Chart";
 import ChartResult from "../component/ChartResult";
+
 import { setHeapMemoryData } from "../features/heapMemory/heapMemorySlice";
 
 export default function OutputResult() {
@@ -27,6 +28,7 @@ export default function OutputResult() {
   return (
     <>
       <Chart />
+      <ChartModal />
       <ChartResult />
     </>
   );

--- a/src/utils/ChartNode.js
+++ b/src/utils/ChartNode.js
@@ -9,7 +9,6 @@ module.exports = class ChartNode {
     this.radius = radius;
     this.ctx = ctx;
     this.data = data;
-    this.modal = null;
 
     this.draw = (color) => {
       this.ctx.beginPath();
@@ -45,20 +44,7 @@ module.exports = class ChartNode {
         Math.pow(x - centerX, 2) + Math.pow(y - centerY, 2),
       );
 
-      if (Math.round(distance) <= radius) {
-        if (!this.modal) {
-          this.modal = document.createElement("div");
-          this.modal.id = `chartModal-${this.data.timestamp}`;
-          document.body.appendChild(this.modal);
-        }
-
-        return true;
-      } else {
-        if (this.modal) {
-          document.body.removeChild(this.modal);
-          this.modal = null;
-        }
-      }
+      if (Math.round(distance) <= radius) return true;
 
       return false;
     };

--- a/src/utils/LineChart.js
+++ b/src/utils/LineChart.js
@@ -10,7 +10,7 @@ const NODE_RADIUS = 4;
 const CHART_MARGIN_NODE = 5;
 
 export default class LineChart {
-  constructor(id, callback) {
+  constructor(id, modalCallback) {
     this.canvas = document.getElementById(id);
     this.ctx = this.canvas.getContext("2d");
 
@@ -30,9 +30,8 @@ export default class LineChart {
     this.heightPixelWeights = 0;
 
     this.snapshotNodes = [];
-    this.removeCodeTypeArray = ["Statement", "Declaration", "Expression"];
 
-    this.checkNodeHover = callback;
+    this.checkNodeHover = modalCallback;
 
     this.canvas.addEventListener("mousemove", (e) => {
       if (this.intervalID) return;
@@ -46,6 +45,7 @@ export default class LineChart {
         cursorPositionY < this.chartHeight + TOP_PADDING
       ) {
         this.checkNodeHover(false);
+
         this.snapshotNodes.forEach((node) => {
           if (node.isMouseOver(cursorPositionX, cursorPositionY)) {
             const chartModalData = {

--- a/src/utils/LineChart.js
+++ b/src/utils/LineChart.js
@@ -10,7 +10,7 @@ const NODE_RADIUS = 4;
 const CHART_MARGIN_NODE = 5;
 
 export default class LineChart {
-  constructor(id) {
+  constructor(id, callback) {
     this.canvas = document.getElementById(id);
     this.ctx = this.canvas.getContext("2d");
 
@@ -32,6 +32,8 @@ export default class LineChart {
     this.snapshotNodes = [];
     this.removeCodeTypeArray = ["Statement", "Declaration", "Expression"];
 
+    this.checkNodeHover = callback;
+
     this.canvas.addEventListener("mousemove", (e) => {
       if (this.intervalID) return;
 
@@ -43,34 +45,23 @@ export default class LineChart {
         cursorPositionX > Y_PADDING &&
         cursorPositionY < this.chartHeight + TOP_PADDING
       ) {
+        this.checkNodeHover(false);
         this.snapshotNodes.forEach((node) => {
           if (node.isMouseOver(cursorPositionX, cursorPositionY)) {
-            const modal = document.getElementById(`${node.modal.id}`);
+            const chartModalData = {
+              codeCount: node.data.count,
+              codeType: node.data.codeType,
+              codePosition: node.data.codePosition,
+              usedMemory: node.data.usedMemory,
+              timeStamp: node.data.timeStamp,
+            };
+            const chartModalStyles = {
+              visibility: true,
+              top: e.pageY,
+              left: e.pageX,
+            };
 
-            modal.style.visibility = "visible";
-            modal.style.position = "absolute";
-            modal.style.left = e.pageX + "px";
-            modal.style.top = e.pageY + "px";
-            modal.style.backgroundColor = `${color.chartModal}`;
-            modal.style.borderRadius = "10px";
-            modal.style.padding = "10px 20px";
-            modal.style.fontSize = "1rem";
-            modal.innerText = `${node.data.count}th node
-            ${
-              node.data.codeType
-                ? `Type : ` +
-                  this.removeCodeTypeArray
-                    .map((type) => {
-                      if (node.data.codeType.includes(type)) {
-                        return node.data.codeType.replace(type, "");
-                      }
-                    })
-                    .filter((node) => node)
-                : `Code Position : ` + node.data.codePosition
-            }
-            Used Memory : ${node.data.usedMemory}
-            Time : ${Math.floor(Number(node.data.timeStamp)) / 1000} us`;
-
+            this.checkNodeHover(true, chartModalData, chartModalStyles);
             node.draw(color.chartDotHover);
           } else {
             node.draw(color.chartDot);


### PR DESCRIPTION
## 🔹 PR type(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능추가
- [x] 버그 수정, 리펙토링
- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🔹 Summary

- 기존의 DOM을 직접 조작하던 `chart modal`을 `component`로 변경하였습니다.
- `Line Chart`를 생성하던 `msChart` 파일 이름을 -> `LineChart`로 변경하였습니다.

## 🔹 Description

### 기존의 DOM을 직접 조작하던 `chart modal`을 `component`로 변경하였습니다.

- **`ChartModal.js` 컴포넌트를 생성하였습니다.**
    기존에 create element로 모달을 생성, 삭제하였던 로직을 제거하고 이제 모달을 chartModal에서 제어합니다.  
    
    
- **`chartModalSlice`가 생성되었습니다.**
    모달 이벤트는 `Chart.js`에서 발생 된`state`를 리덕스로 변경된 값을 `ChartModal.js`에서 받아 모달을 생성합니다.
    즉, **리덕스를 사용하여 모달의 상태를 변경**하고 있습니다.
    
- **뷰 로직을  `ChartModal.js` 컴포넌트로 분리하였습니다.**

- **`ListChart` 2번째 인자로 `callback` 함수를 받고, 여기에 옵저버 함수를 전달하여 리덕스의 `chartModal`을 변경합니다.**
    `ListChart`안에서 `dispath`를 시도하니, 아래와 같은 에러가 발생하였습니다.
    > 🚫 react-dom.development.js:16227 Uncaught Error: Invalid hook call. Hooks can only be called inside of the body of a function component. 
    
    `dispath`도 `hook` 이라 아래와 같은 규칙에 위반되어 옵저버 함수를 만들어 실행하였습니다.
    
    > 훅 규칙
    ✅ 함수 구성 요소 본문의 최상위 수준에서 호출합니다.
   [✅ 사용자 지정 Hook](https://legacy.reactjs.org/docs/hooks-custom.html) 본문의 최상위 수준에서 호출합니다 .
   
    옵저버 함수는 `Chart` 컴포넌트에 위치하고 있습니다.
    해당 옵저버 함수는 노드가 `hover` 상태일 때 실행됩니다.
    실행된 옵저버 함수는 `hover` 상태일 때 : `setChartModalData`, `setChartModalStyle`를 디스패치 합니다.
    실행된 옵저버 함수는 `hover` 상태가 아닐 때  : `hiddenChartModal`를 디스패치 합니다.
     

## 🔹 Issues


## 🔹 Screenshot


## 🔹 To Reviewer
- 파일 변경이 많습니다. 변수명과 함수명 등 봐주시면 감사하겠습니다.
