### PR TITLE
hotfix: linechart drawChart() 실행 후 객체할당 문제 미동작

### DIFF
--- a/src/utils/LineChart.js
+++ b/src/utils/LineChart.js
@@ -233,6 +233,7 @@ export default class LineChart {
 
     ctx.stroke();
     ctx.restore();
+    return this;
   };
 
   updateData = () => {


### PR DESCRIPTION
## 🔹 PR type(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능추가
- [x] 버그 수정
- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🔹 Summary

- LineChart가 동작하지 않는 문제가 발생 하였습니다. 

## 🔹 Description

<br>앱 실행 - LineChart 인스턴스 생성 - 빈차트 그리기 후 그리기 함수에서 return this를 하지 않았습니다.
<br>차트 컴포넌트의 setState에 객체가 저장되지 않아 동작 버튼에서 차트 객체를 찾지 못해 동작하지 않고있습니다. 

## 🔹 Issues

<br>

## 🔹 To Reviewer
